### PR TITLE
Pass return value from callback to subsequent callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,72 @@ RequireAny(
 )
 ```
 
+### Callbacks
+
+The Program and Command nodes can take a callback. If satisfied, these callbacks will be called with the `tree` at that level, the `parentTree`, and anything returned from the previous callbacks.
+
+```shell
+program --kwarg=value command
+```
+
+```javascript
+Program(
+  'program',
+  {
+    callback: function (tree) {
+      /*
+
+      tree = {
+        name: 'program',
+        command: {name: 'command', ...etc},
+        args: {},
+        flags: {},
+        kwargs: {
+          kwarg: 'value'
+        }
+      };
+
+      */
+
+      return 'Hello, World!';
+    }
+  },
+  KWArg(
+    'kwarg'
+  ),
+  Command(
+    'command',
+    {
+      callback: function (tree, parentTree, data) {
+        /*
+
+      tree = {
+        name: 'command',
+        command: null,
+        args: {},
+        flags: {},
+        kwargs: {}
+      };
+
+      parentTree = {
+        name: 'program',
+        command: {name: 'command', ...etc},
+        args: {},
+        flags: {},
+        kwargs: {
+          kwarg: 'value'
+        }
+      };
+
+      data = 'Hello, World!';
+
+      */
+      }
+    }
+  )
+)
+```
+
 ## Command examples
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ RequireAny(
 
 ### Callbacks
 
-The Program and Command nodes can take a callback. If satisfied, these callbacks will be called with the `tree` at that level, the `parentTree`, and anything returned from the previous callbacks.
+The Program and Command nodes can take a callback. If satisfied, these callbacks will be called with the `tree` at that level, the `parentTree`, and anything returned from the previous callback.
 
 ```shell
 program --kwarg=value command

--- a/examples/example1.js
+++ b/examples/example1.js
@@ -23,6 +23,7 @@
         'command first'
       ],
       callback: function (tree) {
+        console.log('Command: ' + tree.name);
         return tree.args.data;
       }
     },
@@ -39,6 +40,7 @@
           description: 'A sub command',
           usage: 'command first sub',
           callback: function (tree, parentTree, data) {
+            console.log('Command: ' + tree.name);
             console.log(data);
           }
         }
@@ -87,7 +89,7 @@
     )
   );
 
-  var tree = jargs.collect(
+  var fullTree = jargs.collect(
     Program(
       'command',
       {
@@ -95,7 +97,10 @@
         examples: [
           'command first arg',
           'command second --flag --kwarg1=foo --kwarg2=bar arg'
-        ]
+        ],
+        callback: function (tree) {
+          console.log('Program: ' + tree.name);
+        }
       },
       RequireAny(
         firstCommand,
@@ -105,6 +110,6 @@
   );
 
   console.log('Full tree:\n');
-  console.log(tree);
+  console.log(fullTree);
 
 })();

--- a/examples/example1.js
+++ b/examples/example1.js
@@ -66,7 +66,7 @@
     )
   );
 
-  jargs.collect(
+  var tree = jargs.collect(
     Program(
       'command',
       {
@@ -82,5 +82,7 @@
       )
     )
   );
+
+  console.log(tree);
 
 })();

--- a/examples/example1.js
+++ b/examples/example1.js
@@ -21,8 +21,29 @@
       usage: 'command first',
       examples: [
         'command first'
-      ]
-    }
+      ],
+      callback: function (tree) {
+        return tree.args.data;
+      }
+    },
+    RequireAll(
+      Arg(
+        'data',
+        {
+          description: 'Some data to be passed to the sub command'
+        }
+      ),
+      Command(
+        'sub',
+        {
+          description: 'A sub command',
+          usage: 'command first sub',
+          callback: function (tree, parentTree, data) {
+            console.log(data);
+          }
+        }
+      )
+    )
   );
 
   var secondCommand = Command(
@@ -83,6 +104,7 @@
     )
   );
 
+  console.log('Full tree:\n');
   console.log(tree);
 
 })();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jargs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Simple node arg parser with explicit tree structure schema",
   "main": "src/index.js",
   "scripts": {

--- a/src/collect.js
+++ b/src/collect.js
@@ -70,7 +70,7 @@
     }
   }
 
-  function createTree (argv, schema, commands) {
+  function createTree (argv, schema, commands, parentTree) {
     var tree = {
       command: null,
       kwargs: {},
@@ -83,7 +83,7 @@
     }
 
     if (typeof schema.options.callback === 'function') {
-      commands.push(schema.options.callback.bind(null, tree));
+      commands.push(schema.options.callback.bind(null, tree, parentTree));
     }
 
     while (argv.length) {
@@ -96,7 +96,7 @@
         });
 
         if (matchingCommand) {
-          tree.command = createTree(argv, matchingCommand, commands);
+          tree.command = createTree(argv, matchingCommand, commands, tree);
         } else {
           var matchingArg = find(schema.children, function (node) {
             return node._type === 'arg' && !(node.name in tree.args);

--- a/src/collect.js
+++ b/src/collect.js
@@ -72,15 +72,12 @@
 
   function createTree (argv, schema, commands, parentTree) {
     var tree = {
+      name: schema.name,
       command: null,
       kwargs: {},
       flags: {},
       args: {}
     };
-
-    if (schema._type === 'command' || schema._type === 'program') {
-      tree.name = schema.name;
-    }
 
     if (typeof schema.options.callback === 'function') {
       commands.push(schema.options.callback.bind(null, tree, parentTree));

--- a/src/collect.js
+++ b/src/collect.js
@@ -78,7 +78,7 @@
       args: {}
     };
 
-    if (schema._type === 'command') {
+    if (schema._type === 'command' || schema._type === 'program') {
       tree.name = schema.name;
     }
 

--- a/src/collect.js
+++ b/src/collect.js
@@ -160,8 +160,10 @@
 
     checkRequiredArgs(schema, tree);
 
+    var returned;
+
     while (commands.length) {
-      commands.shift()();
+      returned = commands.shift()(returned);
     }
 
     return tree;

--- a/tests/collect.test.js
+++ b/tests/collect.test.js
@@ -349,6 +349,51 @@
       expect(result.command.args.arg2).to.equal('argygain');
     });
 
+    it('should pass parent tree & returned value to subsequent callbacks', function () {
+      var boundCollect = collect.bind(null, 'node', 'browserify', ['argy', 'command2', 'argygain', 'command3']);
+
+      var programSpy = stub().returns(1);
+      var command1Spy = stub().returns(2);
+      var command2Spy = stub().returns(3);
+      var command3Spy = stub().returns(4);
+
+      var result = boundCollect(
+        Program(
+          'program',
+          {callback: programSpy},
+          Arg(
+            'arg1'
+          ),
+          Command(
+            'command1',
+            {callback: command1Spy},
+            Arg(
+              'arg3'
+            )
+          ),
+          Command(
+            'command2',
+            {callback: command2Spy},
+            Arg(
+              'arg2'
+            ),
+            Command(
+              'command3',
+              {callback: command3Spy}
+            )
+          )
+        )
+      );
+
+      expect(programSpy).to.have.been.calledOnce;
+      expect(programSpy).to.have.been.calledWith(result, undefined, undefined);
+      expect(command2Spy).to.have.been.calledOnce;
+      expect(command2Spy).to.have.been.calledWith(result.command, result, 1);
+      expect(command3Spy).to.have.been.calledOnce;
+      expect(command3Spy).to.have.been.calledWith(result.command.command, result.command, 3);
+      expect(command1Spy).not.to.have.been.called;
+    });
+
     it('should return an arg tree from aliases', function () {
       var boundCollect = collect.bind(null, 'node', 'browserify',
         ['b', '-t', 'babelify', '-v', '-o', 'build/index.js', 'src/index.js']);

--- a/tests/collect.test.js
+++ b/tests/collect.test.js
@@ -86,6 +86,7 @@
       );
 
       expect(result).to.eql({
+        name: 'program',
         command: null,
         kwargs: {},
         flags: {},
@@ -109,6 +110,7 @@
       );
 
       expect(result).to.eql({
+        name: 'program',
         command: {
           name: 'install',
           command: null,
@@ -142,6 +144,7 @@
       );
 
       expect(result).to.eql({
+        name: 'program',
         command: {
           name: 'install',
           command: null,
@@ -179,6 +182,7 @@
       );
 
       expect(result).to.eql({
+        name: 'program',
         command: {
           name: 'install',
           command: null,
@@ -221,6 +225,7 @@
       );
 
       expect(result).to.eql({
+        name: 'program',
         command: null,
         kwargs: {
           transform: 'babelify',
@@ -256,6 +261,7 @@
       );
 
       expect(result).to.eql({
+        name: 'program',
         command: {
           name: 'command',
           command: null,
@@ -292,6 +298,7 @@
       );
 
       expect(result).to.eql({
+        name: 'program',
         command: null,
         kwargs: {},
         flags: {},
@@ -426,6 +433,7 @@
       );
 
       expect(result).to.eql({
+        name: 'program',
         command: {
           name: 'build',
           command: null,
@@ -681,6 +689,7 @@
       );
 
       expect(tree).to.eql({
+        name: 'program',
         command: null,
         kwargs: {
           kwarg: 'thing',
@@ -712,6 +721,7 @@
       );
 
       expect(tree).to.eql({
+        name: 'program',
         command: null,
         kwargs: {
           kwarg: 'thing',
@@ -745,6 +755,7 @@
       );
 
       expect(tree).to.eql({
+        name: 'program',
         command: null,
         kwargs: {},
         flags: {
@@ -776,6 +787,7 @@
       );
 
       expect(tree).to.eql({
+        name: 'program',
         command: null,
         kwargs: {},
         flags: {


### PR DESCRIPTION
* Callbacks now receive the `tree`, `parentTree` and any data returned from the previous callback
* The program tree now contains the program name
* Add info about callbacks to readme